### PR TITLE
Update .bowerc

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,4 @@
 {
+    "registry": "https://registry.bower.io",
     "directory": "client/bower_components"
 }


### PR DESCRIPTION
From https://stackoverflow.com/questions/51020317/einvres-request-to-https-bower-herokuapp-com-packages-failed-with-502
Bower is deprecating their registry hosted with Heroku. http://bower.herokuapp.com/ Will not be accessible anymore or it might be down intermittently, therefore, forcing users to a new registry.

Users working on old bower versions can update the .bowerrc file with the following data.

{
  "registry": "https://registry.bower.io"
}